### PR TITLE
animechan's link updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These are the currently supported and planned to add support for APIs:
 | --------------------------- | ----------------------------------------------------------------------------------- | --------- |
 | Anime Facts Rest API        | [Documentation](https://chandan-02.github.io/anime-facts-rest-api/)                 | ✅        |
 | Trace.moe                   | [Documentation](https://soruly.github.io/trace.moe-api/)                            | ✅        |
-| Animechan                   | [Documentation](https://animechan.vercel.app/docs)                                  | ✅        |
+| Animechan                   | [Documentation](https://animechan.xyz/docs)                                         | ✅        |
 | Jikan (MyAnimeList)         | [Documentation](https://jikan.docs.apiary.io/)                                      | ❌        |
 | Waifu Pics                  | [Documentation](https://waifu.pics/docs)                                            | ✅        |
 | Studio Ghibli API           | [Documentation](https://ghibliapi.herokuapp.com/)                                   | ✅        |

--- a/anime_api/__init__.py
+++ b/anime_api/__init__.py
@@ -18,7 +18,7 @@ api_list = [
         "https://soruly.github.io/trace.moe-api/",
         True,
     ),
-    ("Animechan", apis.AnimechanAPI, "https://animechan.vercel.app/docs", True),
+    ("Animechan", apis.AnimechanAPI, "https://animechan.xyz/docs", True),
     ("Jikan", None, "https://jikan.docs.apiary.io/#", False),
     ("Waifu Pics", apis.WaifuPicsAPI, "https://waifu.pics/docs", True),
     ("Studio Ghibli API", apis.StudioGhibliAPI, "https://ghibliapi.herokuapp.com/", True),

--- a/anime_api/apis/animechan/__init__.py
+++ b/anime_api/apis/animechan/__init__.py
@@ -1,6 +1,6 @@
 """
 Base module for the Animechan API. The documentation is available at
-https://animechan.vercel.app/docs
+https://animechan.xyz/docs
 """
 from urllib.parse import quote_plus
 
@@ -13,10 +13,10 @@ from anime_api.apis.animechan.objects import Quote
 
 class AnimechanAPI:
     """
-    Docs: https://animechan.vercel.app/docs
+    Docs: https://animechan.xyz/docs
     """
 
-    endpoint = "https://animechan.vercel.app/api"
+    endpoint = "https://animechan.xyz/api"
 
     def __init__(self, endpoint: typing.Optional[str] = None):
         self.endpoint = endpoint or self.endpoint

--- a/docs/README.md
+++ b/docs/README.md
@@ -352,7 +352,7 @@ If the `get_anime_info` was set to `False` when calling the `search()` method, a
 
 ## Animechan API
 
-The Animechan API is an API to get anime quotes. The API documentation can be found [here](https://animechan.vercel.app/).
+The Animechan API is an API to get anime quotes. The API documentation can be found [here](https://animechan.xyz/).
 
 The Animechan API wrapper can be imported from the `anime_api.apis` module.
 

--- a/tests/test_animechan.py
+++ b/tests/test_animechan.py
@@ -3,7 +3,7 @@ Run tests for the AnimechanAPI class.
 
 Usage:
     cd tests
-    poetry run python -m pytest animechan.py
+    poetry run python -m pytest test_animechan.py
 """
 from anime_api.apis.animechan import AnimechanAPI
 from anime_api.apis.animechan.objects import Quote


### PR DESCRIPTION
Animechan API moved from [animechan.vercel.app](https://animechan.vercel.app) to [animechan.xyz](https://animechan.xyz)

Also updated the docstring for [test_animechan.py](https://github.com/Nekidev/anime-api/compare/main...specarino:anime-api:main#diff-d6f5efb84dd706ef36bda958eccfa948567d9a4d2d37ca209e6b64b782d5fa9b)